### PR TITLE
Fix: Update Document ID to be a string

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -39,12 +39,12 @@ class Document
      *
      * @param   \Devloops\Typesence\Lib\Configuration  $config
      * @param   string                                 $collectionName
-     * @param   int                                    $documentId
+     * @param   string                                 $documentId
      */
     public function __construct(
       Configuration $config,
       string $collectionName,
-      int $documentId
+      string $documentId
     ) {
         $this->config         = $config;
         $this->collectionName = $collectionName;


### PR DESCRIPTION
Typesense actually expects IDs to be Strings - and this is necessary to handle UUIDs in schema